### PR TITLE
Relax dependency on rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "http://rubygems.org"
 # Example:
 #   gem "activesupport", ">= 2.3.5"
 
-gem 'rake', '~> 11.1'
+gem 'rake', '> 11.1'
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.


### PR DESCRIPTION
To be able to install this gem when using later versions of rake, I relaxed the dependency
allowing later versions too. 

I had to regenerate the gemspec locally to be able to test this, I am guessing this is done
upon release or do you want it checked in separately?