### PR TITLE
Fix use of "File.exists?" preventing use with Ruby 3.2

### DIFF
--- a/lib/rake-version/manager.rb
+++ b/lib/rake-version/manager.rb
@@ -52,7 +52,7 @@ module RakeVersion
     end
 
     def read_version
-      raise MissingVersionFile, "Version file doesn't exist: #{version_file}" unless File.exists? version_file
+      raise MissingVersionFile, "Version file doesn't exist: #{version_file}" unless File.exist? version_file
       File.read version_file
     end
 


### PR DESCRIPTION
"File.exists?" was deprecated in Ruby 2.1 and, since, Ruby 3.2, has been removed. Replacing with "File.exist?".